### PR TITLE
Add hot-reload for dev environment

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,46 @@
+# Config file for Air in TOML format
+
+# Working directory
+root = "."
+tmp_dir = "tmp"
+
+[build]
+# Just plain old shell command. You could use `make` as well.
+cmd = "go build -o ./tmp/main ."
+# Binary file yields from `cmd`.
+bin = "tmp/main"
+# Customize binary.
+full_bin = "tmp/main"
+# Watch these filename extensions.
+include_ext = ["go", "tpl", "tmpl", "html", "css", "js"]
+# Ignore these filename extensions or directories.
+exclude_dir = ["tmp", "vendor", "node_modules"]
+# Watch these directories if you specified.
+include_dir = []
+# Exclude files.
+exclude_file = []
+# This log file places in your tmp_dir.
+log = "air.log"
+# It's not necessary to trigger build each time file changes if it's too frequent.
+delay = 1000 # ms
+# Stop running old binary when build errors occur.
+stop_on_error = true
+# Send Interrupt signal before killing process (windows does not support this feature)
+send_interrupt = false
+# Delay after sending Interrupt signal
+kill_delay = 500 # ms
+
+[log]
+# Show log time
+time = false
+
+[color]
+# Customize each part's color.
+main = "magenta"
+watcher = "cyan"
+build = "yellow"
+runner = "green"
+
+[misc]
+# Delete tmp directory on exit
+clean_on_exit = true 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bruno/
 .env
+tmp

--- a/compose-local.yml
+++ b/compose-local.yml
@@ -44,7 +44,11 @@ services:
       - "traefik.http.services.grafana.loadbalancer.server.port=3000"
 
   optiguide:
-    build: .
+    build: 
+      context: .
+      target: dev
+      args:
+        - TARGET=dev
     environment:
       - GOOGLE_ID=${GOOGLE_ID}
       - GOOGLE_SECRET=${GOOGLE_SECRET}
@@ -56,6 +60,9 @@ services:
       - POSTGRES_HOST=postgres
     ports:
       - "8080:8080"
+    volumes:
+      - .:/app
+      - go-modules:/go/pkg/mod
     labels:
       - "traefik.http.routers.optiguide.rule=Host(`optiguide.docker.localhost`)"
     depends_on:
@@ -68,6 +75,8 @@ services:
       - POSTGRES_USER=optiguide
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=optiguide
+    ports:
+      - "5432:5432"
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U optiguide"]
@@ -81,3 +90,4 @@ volumes:
   postgres_data:
   prometheus_data:
   grafana_data:
+  go-modules:


### PR DESCRIPTION
These changes improve the local development environment by adding hot reload. 
I don't know if there is an alternative to develop locally with hot reloading ?

My suggestions :

- Introduced a new configuration file for Air to enable hot reloading during development.
- Updated Dockerfile to include a development stage that installs Air and sets it up for use.
- Modified `compose-local.yml` to specify build context and added volume mappings for local development.
- Enhanced the Dockerfile to support multi-stage builds, allowing for a cleaner production image.